### PR TITLE
Convert to use left4devops base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,25 @@
-FROM ubuntu:18.04
+# Left4DevOps rocky linux-based base image
+FROM left4devops/l4d2
 
-ENV USER l4d2
-ENV HOME /home/$USER
-ENV SERVER $HOME/hlserver
+USER root
+# Install rsync and find to make the copy job easier
+RUN microdnf install -y rsync findutils && \
+    microdnf clean all
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBCONF_NONINTERACTIVE_SEEN true
+USER louis
+RUN curl https://codeload.github.com/SirPlease/L4D2-Competitive-Rework/tar.gz/refs/heads/master | tar -xvz \
+  && find L4D2-Competitive-Rework-master/addons -iname "*.dll" -exec rm {} ';' \
+  && rsync -K -a L4D2-Competitive-Rework-master/scripts/* $INSTALL_DIR/left4dead2/scripts/ \
+  && rsync -K -a L4D2-Competitive-Rework-master/addons/* $INSTALL_DIR/left4dead2/addons/ \
+  && rsync -K -a L4D2-Competitive-Rework-master/cfg/* $INSTALL_DIR/left4dead2/cfg/ \
+  && rm -rf L4D2-Competitive-Rework-master
 
-RUN apt-get -y update \
-    && apt-get -y install lib32gcc1 curl net-tools lib32stdc++6 locales unzip lib32z1 screen \
-    && locale-gen en_US.UTF-8 \
-    && update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
-    && dpkg-reconfigure --frontend noninteractive locales \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# New vars supported
+ENV TICKRATE=100 \
+    MAXPLAYERS=8 \
+    DEFAULT_MAP=c1m1_hotel \
+    IP=0.0.0.0
 
-RUN useradd --create-home $USER
+ADD entrypoint.sh .
 
-USER $USER
-
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
-
-RUN mkdir $SERVER
-COPY ./l4d2_ds.txt $SERVER/l4d2_ds.txt
-COPY ./update.sh $SERVER/update.sh
-COPY ./l4d2.sh $SERVER/l4d2.sh
-RUN curl --silent --show-error http://media.steampowered.com/client/steamcmd_linux.tar.gz | tar -C $SERVER -xvz \
-    && $SERVER/update.sh
-RUN curl --silent --show-error https://mms.alliedmods.net/mmsdrop/1.10/mmsource-1.10.7-git971-linux.tar.gz | tar xvz -C $SERVER/l4d2/left4dead2
-RUN curl --silent --show-error https://sm.alliedmods.net/smdrop/1.10/sourcemod-1.10.0-git6498-linux.tar.gz | tar xvz -C $SERVER/l4d2/left4dead2
-RUN curl --silent --show-error --location --output $HOME/tmp.zip https://github.com/SirPlease/L4D2-Competitive-Rework/archive/master.zip \
-    && unzip -v $HOME/tmp.zip -d $SERVER/l4d2/left4dead2 \
-    && rm $HOME/tmp.zip
-
-EXPOSE 27015/udp
-
-WORKDIR $SERVER
-ENTRYPOINT ["./l4d2.sh"]
-CMD ["-console" "-usercon" "+map" "c1m1_hotel"]
+ENTRYPOINT  ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# set -x
+
+./steamcmd.sh +runscript update.txt
+
+cd "${INSTALL_DIR}" || exit 50
+
+if [ "${INSTALL_DIR}" = "l4d2" ]; then
+    GAME_DIR="left4dead2"
+elif [ "${INSTALL_DIR}" = "l4d" ]; then
+    GAME_DIR="left4dead"
+else
+    exit 100
+fi
+
+if [ $# -gt 0 ]; then
+    ./srcds_run "$@"
+else
+    STARTUP=("./srcds_run")
+
+    STARTUP+=("-timeout 10")
+
+    if [[ "${TICKRATE}" -gt 0 ]]; then
+        STARTUP+=("-tickrate ${TICKRATE}")
+    fi
+    
+    STARTUP+=("+sv_logecho 1")
+    STARTUP+=("+hostname \"${HOSTNAME}\"")
+    STARTUP+=("+sv_region ${REGION}")
+
+    STARTUP+=("+motd_enabled ${MOTD}")
+
+    if [[ -e "${GAME_DIR}/myhost.txt" ]]; then
+      STARTUP+=("+hostfile myhost.txt")
+    elif [ -n "${HOST_CONTENT}" ]; then
+      echo "${HOST_CONTENT}" > "${GAME_DIR}/envhost.txt"
+      STARTUP+=("+hostfile envhost.txt")
+    else
+      echo "${HOSTNAME}" > "${GAME_DIR}/myhostname.txt"
+      STARTUP+=("+hostfile myhostname.txt")
+    fi
+
+    if [[ -e "${GAME_DIR}/mymotd.txt" ]]; then
+      STARTUP+=("+motdfile mymotd.txt")
+    elif [ -n "${MOTD_CONTENT}" ]; then
+      echo "${MOTD_CONTENT}" > "${GAME_DIR}/envmotd.txt"
+      STARTUP+=("+motdfile envmotd.txt")
+    fi
+
+    if [ "${STEAM_GROUP}" -gt 0 ]; then
+        STARTUP+=("+sv_steamgroup ${STEAM_GROUP}")
+        if [ "${STEAM_GROUP_EXCLUSIVE}" ] ; then
+            STARTUP+=("+sv_steamgroup_exclusive 1")
+        fi
+    fi
+
+    if [ "${MAXPLAYERS}" -gt 0 ]; then
+        STARTUP+=("-maxplayers ${MAXPLAYERS}")
+    fi
+
+    if [ -n "${IP}" ]; then 
+        STARTUP+=("-ip ${IP}")
+    fi
+
+    STARTUP+=("+map $DEFAULT_MAP")
+
+    if [ -n "${GAME_TYPES}" ]; then
+        STARTUP+=("+sv_gametypes \"${GAME_TYPES}\"")
+    fi
+
+    if [ "${FORK:-0}" -gt 0 ]; then
+        STARTUP+=("-fork ${FORK} +exec server##.cfg")
+    else
+        if [ "${PORT:-0}" -gt 0 ]; then
+            STARTUP+=("-port $PORT")
+        fi
+    fi
+
+    if [ "${LAN}" ] ; then
+        STARTUP+=("+sv_lan 1")
+    fi
+
+    if [ -n "${RCON_PASSWORD}" ]; then
+        STARTUP+=("+rcon_password \"${RCON_PASSWORD}\"")
+    fi
+
+    if [ "${NET_CON_PORT:-0}" -gt 0 ]; then
+        STARTUP+=("-netconport ${NET_CON_PORT}")
+        if [ -n "${NET_CON_PASSWORD}" ]; then
+            STARTUP+=("-netconpassword \"${NET_CON_PASSWORD}\"")
+        fi
+    fi
+
+    if [ -n "${EXTRA_ARGS}" ]; then
+        STARTUP+=("${EXTRA_ARGS}")
+    fi
+
+    ${STARTUP[*]}
+fi

--- a/l4d2.sh
+++ b/l4d2.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-cd "$HOME/hlserver" || exit
-l4d2/srcds_run -game left4dead2 -tickrate 100 -autoupdate -steam_dir ~/hlserver -steamcmd_script ~/hlserver/l4d2_ds.txt "$@"

--- a/l4d2_ds.txt
+++ b/l4d2_ds.txt
@@ -1,4 +1,0 @@
-login anonymous
-force_install_dir ./l4d2
-app_update 222860 validate
-quit

--- a/update.sh
+++ b/update.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-cd "$HOME/hlserver" || exit
-./steamcmd.sh +runscript l4d2_ds.txt


### PR DESCRIPTION
The https://github.com/Left4DevOps/l4d2-docker base image is already fully functioning to run l4d2, we just need to install rework on top of it.

By using this based image, we only really need to add l4d2-rework on top. We technically don't need to modify the entrypoint, but it doesn't hurt to customize it a bit for common l4d2-rework options.